### PR TITLE
Changes front

### DIFF
--- a/bingo_backend/bingo_backend/settings.py
+++ b/bingo_backend/bingo_backend/settings.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = [
     'rest_framework.authtoken',
     'bingo_room',
     'game_session',
+    'corsheaders',
 ]
 
 MIDDLEWARE = [
@@ -56,6 +57,8 @@ MIDDLEWARE = [
 
 AUTH_USER_MODEL = 'users.User'
 ROOT_URLCONF = 'bingo_backend.urls'
+#PARA DEV
+CORS_ALLOW_ALL_ORIGINS = True
 
 TEMPLATES = [
     {

--- a/bingo_backend/bingo_backend/urls.py
+++ b/bingo_backend/bingo_backend/urls.py
@@ -5,4 +5,5 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include('users.urls')),  # All user endpoints will be under /api/users/
     path('api/', include('bingo_room.urls')),
+    path('api/', include('game_session.urls')),
 ]


### PR DESCRIPTION
Habilita CORS para integração com o front-end

- Adiciona 'corsheaders' em INSTALLED_APPS
- Adiciona 'corsheaders.middleware.CorsMiddleware' no início do MIDDLEWARE
- Define CORS_ALLOW_ALL_ORIGINS = True para permitir requisições de qualquer origem durante o desenvolvimento